### PR TITLE
Enable weather provider selection

### DIFF
--- a/src/app/cli.py
+++ b/src/app/cli.py
@@ -18,13 +18,14 @@ from .pipelines.backtest import BacktestPipeline
 from .pipelines.parlays import ParlayOptimizer
 from .models.train import ModelTrainer
 from .models.calibration import ModelCalibrator
+from .providers.weather_meteostat import MeteostatWeatherProvider
+from .providers.weather_weatherapi import WeatherAPIProvider
 
 # Initialize CLI app
 app = typer.Typer(help="CFB Edge Detection Platform")
 console = Console()
 
 # Initialize pipelines
-ingest_pipeline = IngestPipeline()
 normalize_pipeline = NormalizePipeline()
 feature_pipeline = FeaturePipeline()
 labels_pipeline = LabelsPipeline()
@@ -40,37 +41,48 @@ def ingest(
     week: Optional[int] = typer.Option(None, help="Specific week (optional)"),
     odds_provider: str = typer.Option("theodds", help="Odds provider"),
     cfbd: bool = typer.Option(True, help="Include CFBD data"),
-    weather: Optional[str] = typer.Option(None, help="Weather provider (meteostat)"),
+    weather: Optional[str] = typer.Option(
+        None, help="Weather provider (meteostat, weatherapi)"
+    ),
 ):
     """Ingest data from various sources."""
     setup_logging()
     logger = get_logger(__name__)
-    
+
     console.print(f"[bold blue]Ingesting data for season {season}[/bold blue]")
     if week:
         console.print(f"Week: {week}")
-    
+
+    weather_provider = None
+    if weather:
+        if weather.lower() == "meteostat":
+            weather_provider = MeteostatWeatherProvider()
+        elif weather.lower() == "weatherapi":
+            weather_provider = WeatherAPIProvider()
+        else:
+            raise typer.BadParameter("Unsupported weather provider")
+
+    ingest_pipeline = IngestPipeline(weather_provider=weather_provider)
+
     try:
         results = ingest_pipeline.run_full_ingest(
-            season=season,
-            week=week,
-            include_weather=weather is not None
+            season=season, week=week, include_weather=weather_provider is not None
         )
-        
+
         # Display results
         table = Table(title="Ingestion Results")
         table.add_column("Source", style="cyan")
         table.add_column("Records", style="green")
-        
+
         for source, data in results.items():
-            if hasattr(data, '__len__'):
+            if hasattr(data, "__len__"):
                 table.add_row(source, str(len(data)))
             else:
                 table.add_row(source, "N/A")
-        
+
         console.print(table)
         console.print("[bold green]Ingestion completed successfully![/bold green]")
-        
+
     except Exception as e:
         console.print(f"[bold red]Error during ingestion: {e}[/bold red]")
         raise typer.Exit(1)
@@ -83,16 +95,16 @@ def build_features(
     """Build feature engineering pipeline."""
     setup_logging()
     logger = get_logger(__name__)
-    
+
     console.print(f"[bold blue]Building features as of {as_of}[/bold blue]")
-    
+
     try:
         features_df = feature_pipeline.run_feature_engineering(as_of)
-        
+
         console.print(f"[bold green]Features built successfully![/bold green]")
         console.print(f"Records: {len(features_df)}")
         console.print(f"Features: {len(features_df.columns)}")
-        
+
     except Exception as e:
         console.print(f"[bold red]Error building features: {e}[/bold red]")
         raise typer.Exit(1)
@@ -105,30 +117,32 @@ def train(
     """Train ML model for a specific market."""
     setup_logging()
     logger = get_logger(__name__)
-    
+
     console.print(f"[bold blue]Training model for market: {market}[/bold blue]")
-    
+
     try:
         # Train model
         model_results = model_trainer.train_market_model(market)
-        
+
         # Display metrics
         table = Table(title=f"Model Performance - {market}")
         table.add_column("Metric", style="cyan")
         table.add_column("Value", style="green")
-        
-        for metric, value in model_results['metrics'].items():
+
+        for metric, value in model_results["metrics"].items():
             table.add_row(metric, f"{value:.4f}")
-        
+
         console.print(table)
-        
+
         # Calibrate model
         console.print("[bold blue]Calibrating model...[/bold blue]")
         calibration_results = model_calibrator.calibrate_market_model(market)
-        
+
         console.print(f"[bold green]Model training completed![/bold green]")
-        console.print(f"Brier Score: {calibration_results['metrics']['brier_score']:.4f}")
-        
+        console.print(
+            f"Brier Score: {calibration_results['metrics']['brier_score']:.4f}"
+        )
+
     except Exception as e:
         console.print(f"[bold red]Error training model: {e}[/bold red]")
         raise typer.Exit(1)
@@ -142,28 +156,30 @@ def backtest(
     """Run backtest for a specific season and market."""
     setup_logging()
     logger = get_logger(__name__)
-    
-    console.print(f"[bold blue]Running backtest for season {season}, market {market}[/bold blue]")
-    
+
+    console.print(
+        f"[bold blue]Running backtest for season {season}, market {market}[/bold blue]"
+    )
+
     try:
         results = backtest_pipeline.run_backtest(season, market)
-        
+
         # Display metrics
         table = Table(title=f"Backtest Results - {market}")
         table.add_column("Metric", style="cyan")
         table.add_column("Value", style="green")
-        
-        metrics = results['metrics']
-        table.add_row("Total Bets", str(metrics['total_bets']))
+
+        metrics = results["metrics"]
+        table.add_row("Total Bets", str(metrics["total_bets"]))
         table.add_row("Hit Rate", f"{metrics['hit_rate']:.3f}")
         table.add_row("Total Return", f"${metrics['total_return']:.2f}")
         table.add_row("Total EV", f"${metrics['total_ev']:.2f}")
         table.add_row("Max Drawdown", f"${metrics['max_drawdown']:.2f}")
         table.add_row("Sharpe Ratio", f"{metrics['sharpe_ratio']:.3f}")
-        
+
         console.print(table)
         console.print("[bold green]Backtest completed successfully![/bold green]")
-        
+
     except Exception as e:
         console.print(f"[bold red]Error during backtest: {e}[/bold red]")
         raise typer.Exit(1)
@@ -178,24 +194,24 @@ def make_parlays(
     """Generate parlay recommendations."""
     setup_logging()
     logger = get_logger(__name__)
-    
+
     # Parse risk percentage
-    risk_percentage = float(risk.replace('%', ''))
-    
-    console.print(f"[bold blue]Generating parlay recommendations for {date}[/bold blue]")
+    risk_percentage = float(risk.replace("%", ""))
+
+    console.print(
+        f"[bold blue]Generating parlay recommendations for {date}[/bold blue]"
+    )
     console.print(f"Top N: {top_n}, Risk: {risk_percentage}%")
-    
+
     try:
         recommendations = parlay_optimizer.run_parlay_optimization(
-            date=date,
-            top_n=top_n,
-            risk_percentage=risk_percentage
+            date=date, top_n=top_n, risk_percentage=risk_percentage
         )
-        
+
         if not recommendations:
             console.print("[bold yellow]No profitable parlays found[/bold yellow]")
             return
-        
+
         # Display top recommendations
         table = Table(title=f"Top Parlay Recommendations - {date}")
         table.add_column("Parlay ID", style="cyan")
@@ -205,21 +221,23 @@ def make_parlays(
         table.add_column("EV", style="red")
         table.add_column("Stake", style="blue")
         table.add_column("Potential Return", style="green")
-        
+
         for rec in recommendations[:10]:  # Show top 10
             table.add_row(
-                rec['parlay_id'],
-                str(rec['legs']),
+                rec["parlay_id"],
+                str(rec["legs"]),
                 f"{rec['parlay_prob']:.3f}",
                 f"{rec['parlay_odds']:.2f}",
                 f"{rec['ev']:.3f}",
                 f"${rec['recommended_stake']:.2f}",
-                f"${rec['potential_return']:.2f}"
+                f"${rec['potential_return']:.2f}",
             )
-        
+
         console.print(table)
-        console.print(f"[bold green]Generated {len(recommendations)} parlay recommendations![/bold green]")
-        
+        console.print(
+            f"[bold green]Generated {len(recommendations)} parlay recommendations![/bold green]"
+        )
+
     except Exception as e:
         console.print(f"[bold red]Error generating parlays: {e}[/bold red]")
         raise typer.Exit(1)
@@ -233,18 +251,18 @@ def normalize(
     """Normalize and clean ingested data."""
     setup_logging()
     logger = get_logger(__name__)
-    
+
     console.print(f"[bold blue]Normalizing data for season {season}[/bold blue]")
     if week:
         console.print(f"Week: {week}")
-    
+
     try:
         normalized_df = normalize_pipeline.run_normalization(season, week)
-        
+
         console.print(f"[bold green]Normalization completed![/bold green]")
         console.print(f"Records: {len(normalized_df)}")
         console.print(f"Columns: {len(normalized_df.columns)}")
-        
+
     except Exception as e:
         console.print(f"[bold red]Error during normalization: {e}[/bold red]")
         raise typer.Exit(1)
@@ -258,26 +276,26 @@ def create_labels(
     """Create betting outcome labels."""
     setup_logging()
     logger = get_logger(__name__)
-    
+
     console.print(f"[bold blue]Creating labels for season {season}[/bold blue]")
     if week:
         console.print(f"Week: {week}")
-    
+
     try:
         labels_dict = labels_pipeline.run_label_creation(season, week)
-        
+
         console.print(f"[bold green]Label creation completed![/bold green]")
-        
+
         # Display label counts
         table = Table(title="Label Creation Results")
         table.add_column("Market-Period", style="cyan")
         table.add_column("Records", style="green")
-        
+
         for market_period, labels_df in labels_dict.items():
             table.add_row(market_period, str(len(labels_df)))
-        
+
         console.print(table)
-        
+
     except Exception as e:
         console.print(f"[bold red]Error creating labels: {e}[/bold red]")
         raise typer.Exit(1)
@@ -287,12 +305,12 @@ def create_labels(
 def status():
     """Show platform status and configuration."""
     console.print("[bold blue]CFB Edge Platform Status[/bold blue]")
-    
+
     # Configuration
     table = Table(title="Configuration")
     table.add_column("Setting", style="cyan")
     table.add_column("Value", style="green")
-    
+
     table.add_row("Data Directory", str(settings.data_dir))
     table.add_row("Artifacts Directory", str(settings.artifacts_dir))
     table.add_row("Random Seed", str(settings.random_seed))
@@ -300,18 +318,18 @@ def status():
     table.add_row("Calibration Method", settings.calibration_method)
     table.add_row("Transaction Cost", f"${settings.transaction_cost:.2f}")
     table.add_row("Max Kelly Fraction", f"{settings.max_kelly_fraction:.2f}")
-    
+
     console.print(table)
-    
+
     # Check API keys
     api_table = Table(title="API Keys")
     api_table.add_column("Provider", style="cyan")
     api_table.add_column("Status", style="green")
-    
+
     api_table.add_row("CFBD", "✓" if settings.cfbd_api_key else "✗")
     api_table.add_row("Odds API", "✓" if settings.odds_api_key else "✗")
     api_table.add_row("Weather", "✓" if settings.weather_api_key else "✗")
-    
+
     console.print(api_table)
 
 

--- a/src/app/pipelines/ingest.py
+++ b/src/app/pipelines/ingest.py
@@ -11,132 +11,140 @@ from ..config import settings
 from ..logging import get_logger
 from ..providers.cfbd_client import CFBDClient
 from ..providers.odds_theoddsapi import OddsAPIClient
-from ..providers.weather_meteostat import WeatherProvider
+from ..providers.weather_meteostat import MeteostatWeatherProvider
 
 logger = get_logger(__name__)
 
 
 class IngestPipeline:
     """Pipeline for ingesting raw data from various sources."""
-    
-    def __init__(self):
+
+    def __init__(self, weather_provider: Optional[object] = None):
         """Initialize ingestion pipeline."""
         self.cfbd_client = CFBDClient()
         self.odds_client = OddsAPIClient()
-        self.weather_provider = WeatherProvider()
+        self.weather_provider = weather_provider or MeteostatWeatherProvider()
         self.data_dir = settings.data_dir / "bronze"
-    
+
     def ingest_games(self, season: int, week: Optional[int] = None) -> pd.DataFrame:
         """Ingest games data from CFBD."""
-        logger.info(f"Ingesting games for season {season}" + (f", week {week}" if week else ""))
-        
+        logger.info(
+            f"Ingesting games for season {season}" + (f", week {week}" if week else "")
+        )
+
         games_df = self.cfbd_client.fetch_games(season, week)
-        
+
         # Save to bronze layer
         filename = f"games_{season}" + (f"_week_{week}" if week else "") + ".parquet"
         filepath = self.data_dir / filename
         games_df.to_parquet(filepath, index=False)
-        
+
         logger.info(f"Saved {len(games_df)} games to {filepath}")
         return games_df
-    
+
     def ingest_odds(self, season: int, week: Optional[int] = None) -> pd.DataFrame:
         """Ingest odds data from The Odds API."""
-        logger.info(f"Ingesting odds for season {season}" + (f", week {week}" if week else ""))
-        
+        logger.info(
+            f"Ingesting odds for season {season}" + (f", week {week}" if week else "")
+        )
+
         odds_df = self.odds_client.fetch_odds(season, week)
-        
+
         if not odds_df.empty:
             # Save to bronze layer
             filename = f"odds_{season}" + (f"_week_{week}" if week else "") + ".parquet"
             filepath = self.data_dir / filename
             odds_df.to_parquet(filepath, index=False)
-            
+
             logger.info(f"Saved {len(odds_df)} odds records to {filepath}")
         else:
             logger.warning("No odds data to save")
-        
+
         return odds_df
-    
+
     def ingest_weather(self, games_df: pd.DataFrame) -> pd.DataFrame:
         """Ingest weather data for games."""
         logger.info(f"Ingesting weather data for {len(games_df)} games")
-        
+
         weather_df = self.weather_provider.fetch_weather(games_df)
-        
+
         if not weather_df.empty:
             # Save to bronze layer
             filename = f"weather_{datetime.now().strftime('%Y%m%d')}.parquet"
             filepath = self.data_dir / filename
             weather_df.to_parquet(filepath, index=False)
-            
+
             logger.info(f"Saved {len(weather_df)} weather records to {filepath}")
         else:
             logger.warning("No weather data to save")
-        
+
         return weather_df
-    
+
     def ingest_team_stats(self, season: int) -> pd.DataFrame:
         """Ingest team statistics from CFBD."""
         logger.info(f"Ingesting team stats for season {season}")
-        
+
         stats_df = self.cfbd_client.fetch_team_stats(season)
-        
+
         # Save to bronze layer
         filename = f"team_stats_{season}.parquet"
         filepath = self.data_dir / filename
         stats_df.to_parquet(filepath, index=False)
-        
+
         logger.info(f"Saved {len(stats_df)} team stats records to {filepath}")
         return stats_df
-    
+
     def ingest_ratings(self, season: int) -> pd.DataFrame:
         """Ingest team ratings from CFBD."""
         logger.info(f"Ingesting ratings for season {season}")
-        
+
         ratings_df = self.cfbd_client.fetch_ratings(season)
-        
+
         # Save to bronze layer
         filename = f"ratings_{season}.parquet"
         filepath = self.data_dir / filename
         ratings_df.to_parquet(filepath, index=False)
-        
+
         logger.info(f"Saved {len(ratings_df)} ratings records to {filepath}")
         return ratings_df
-    
-    def run_full_ingest(self, season: int, week: Optional[int] = None, 
-                        include_weather: bool = True) -> dict:
+
+    def run_full_ingest(
+        self, season: int, week: Optional[int] = None, include_weather: bool = True
+    ) -> dict:
         """Run full ingestion pipeline."""
-        logger.info(f"Starting full ingest for season {season}" + (f", week {week}" if week else ""))
-        
+        logger.info(
+            f"Starting full ingest for season {season}"
+            + (f", week {week}" if week else "")
+        )
+
         results = {}
-        
+
         try:
             # Ingest games
             games_df = self.ingest_games(season, week)
-            results['games'] = games_df
-            
+            results["games"] = games_df
+
             # Ingest odds
             odds_df = self.ingest_odds(season, week)
-            results['odds'] = odds_df
-            
+            results["odds"] = odds_df
+
             # Ingest weather (if requested and games available)
             if include_weather and not games_df.empty:
                 weather_df = self.ingest_weather(games_df)
-                results['weather'] = weather_df
-            
+                results["weather"] = weather_df
+
             # Ingest team stats and ratings (season-level only)
             if week is None:
                 stats_df = self.ingest_team_stats(season)
-                results['team_stats'] = stats_df
-                
+                results["team_stats"] = stats_df
+
                 ratings_df = self.ingest_ratings(season)
-                results['ratings'] = ratings_df
-            
+                results["ratings"] = ratings_df
+
             logger.info("Full ingest completed successfully")
-            
+
         except Exception as e:
             logger.error(f"Error during full ingest: {e}")
             raise
-        
+
         return results

--- a/src/app/providers/weather_meteostat.py
+++ b/src/app/providers/weather_meteostat.py
@@ -13,128 +13,130 @@ from ..logging import get_logger
 logger = get_logger(__name__)
 
 
-class WeatherProvider:
+class MeteostatWeatherProvider:
     """Weather data provider using Meteostat."""
-    
+
     def __init__(self, api_key: Optional[str] = None):
         """Initialize weather provider."""
         self.api_key = api_key or settings.weather_api_key
         # Meteostat doesn't require API key for basic usage
-    
+
     def _get_stadium_location(self, team: str) -> Optional[Point]:
         """Get stadium coordinates for a team."""
         # This is a simplified mapping - in production, you'd want a comprehensive database
         stadium_locations = {
-            'Alabama': Point(33.2084, -87.5504),  # Bryant-Denny Stadium
-            'Auburn': Point(32.6024, -85.4902),   # Jordan-Hare Stadium
-            'Georgia': Point(33.9500, -83.3750),   # Sanford Stadium
-            'Florida': Point(29.6500, -82.3500),  # Ben Hill Griffin Stadium
-            'LSU': Point(30.4115, -91.1899),      # Tiger Stadium
-            'Texas': Point(30.2836, -97.7316),    # Darrell K Royal Stadium
-            'Oklahoma': Point(35.2058, -97.4456), # Gaylord Family Stadium
-            'Ohio State': Point(40.0019, -83.0197), # Ohio Stadium
-            'Michigan': Point(42.2658, -83.7485),  # Michigan Stadium
-            'Penn State': Point(40.8123, -77.8561), # Beaver Stadium
-            'USC': Point(34.2569, -118.2879),      # Los Angeles Memorial Coliseum
-            'UCLA': Point(34.0722, -118.2437),    # Rose Bowl
-            'Notre Dame': Point(41.6990, -86.2384), # Notre Dame Stadium
-            'Clemson': Point(34.6788, -82.8373),  # Memorial Stadium
-            'Florida State': Point(30.4419, -84.2911), # Doak Campbell Stadium
-            'Miami': Point(25.6081, -80.4090),    # Hard Rock Stadium
-            'Stanford': Point(37.4341, -122.1637), # Stanford Stadium
-            'Oregon': Point(44.0582, -123.0703),  # Autzen Stadium
-            'Washington': Point(47.6500, -122.3031), # Husky Stadium
-            'Wisconsin': Point(43.0708, -89.4062), # Camp Randall Stadium
-            'Iowa': Point(41.6581, -91.5517),    # Kinnick Stadium
-            'Nebraska': Point(40.8207, -96.7056), # Memorial Stadium
-            'Michigan State': Point(42.7258, -84.4806), # Spartan Stadium
-            'Minnesota': Point(44.9778, -93.2225), # Huntington Bank Stadium
-            'Northwestern': Point(42.0650, -87.6967), # Ryan Field
-            'Purdue': Point(40.4259, -86.9142),   # Ross-Ade Stadium
-            'Indiana': Point(39.1817, -86.5264),  # Memorial Stadium
-            'Illinois': Point(40.1020, -88.2272), # Memorial Stadium
-            'Maryland': Point(38.9887, -76.9376), # Maryland Stadium
-            'Rutgers': Point(40.5008, -74.4474),  # SHI Stadium
+            "Alabama": Point(33.2084, -87.5504),  # Bryant-Denny Stadium
+            "Auburn": Point(32.6024, -85.4902),  # Jordan-Hare Stadium
+            "Georgia": Point(33.9500, -83.3750),  # Sanford Stadium
+            "Florida": Point(29.6500, -82.3500),  # Ben Hill Griffin Stadium
+            "LSU": Point(30.4115, -91.1899),  # Tiger Stadium
+            "Texas": Point(30.2836, -97.7316),  # Darrell K Royal Stadium
+            "Oklahoma": Point(35.2058, -97.4456),  # Gaylord Family Stadium
+            "Ohio State": Point(40.0019, -83.0197),  # Ohio Stadium
+            "Michigan": Point(42.2658, -83.7485),  # Michigan Stadium
+            "Penn State": Point(40.8123, -77.8561),  # Beaver Stadium
+            "USC": Point(34.2569, -118.2879),  # Los Angeles Memorial Coliseum
+            "UCLA": Point(34.0722, -118.2437),  # Rose Bowl
+            "Notre Dame": Point(41.6990, -86.2384),  # Notre Dame Stadium
+            "Clemson": Point(34.6788, -82.8373),  # Memorial Stadium
+            "Florida State": Point(30.4419, -84.2911),  # Doak Campbell Stadium
+            "Miami": Point(25.6081, -80.4090),  # Hard Rock Stadium
+            "Stanford": Point(37.4341, -122.1637),  # Stanford Stadium
+            "Oregon": Point(44.0582, -123.0703),  # Autzen Stadium
+            "Washington": Point(47.6500, -122.3031),  # Husky Stadium
+            "Wisconsin": Point(43.0708, -89.4062),  # Camp Randall Stadium
+            "Iowa": Point(41.6581, -91.5517),  # Kinnick Stadium
+            "Nebraska": Point(40.8207, -96.7056),  # Memorial Stadium
+            "Michigan State": Point(42.7258, -84.4806),  # Spartan Stadium
+            "Minnesota": Point(44.9778, -93.2225),  # Huntington Bank Stadium
+            "Northwestern": Point(42.0650, -87.6967),  # Ryan Field
+            "Purdue": Point(40.4259, -86.9142),  # Ross-Ade Stadium
+            "Indiana": Point(39.1817, -86.5264),  # Memorial Stadium
+            "Illinois": Point(40.1020, -88.2272),  # Memorial Stadium
+            "Maryland": Point(38.9887, -76.9376),  # Maryland Stadium
+            "Rutgers": Point(40.5008, -74.4474),  # SHI Stadium
         }
-        
+
         return stadium_locations.get(team)
-    
+
     def fetch_weather(self, games_df: pd.DataFrame) -> pd.DataFrame:
         """Fetch weather data for games."""
         weather_data = []
-        
+
         for _, game in games_df.iterrows():
             try:
                 # Get stadium location
-                home_location = self._get_stadium_location(game['home'])
+                home_location = self._get_stadium_location(game["home"])
                 if not home_location:
                     logger.warning(f"No location data for {game['home']}")
                     continue
-                
+
                 # Get weather data around kickoff time
-                kickoff = game['kickoff_utc']
+                kickoff = game["kickoff_utc"]
                 start_time = kickoff - timedelta(hours=2)
                 end_time = kickoff + timedelta(hours=2)
-                
+
                 # Fetch hourly weather data
                 weather = Hourly(home_location, start_time, end_time)
                 weather = weather.fetch()
-                
+
                 if weather.empty:
                     logger.warning(f"No weather data for {game['home']} at {kickoff}")
                     continue
-                
+
                 # Find closest hour to kickoff
-                weather['time_diff'] = abs((weather.index - kickoff).total_seconds())
-                closest_hour = weather.loc[weather['time_diff'].idxmin()]
-                
-                weather_data.append({
-                    'game_id': game['game_id'],
-                    'kickoff_utc': kickoff,
-                    'temp_c': closest_hour.get('temp'),
-                    'wind_mps': closest_hour.get('wspd'),
-                    'precip_mm': closest_hour.get('prcp'),
-                    'humidity': closest_hour.get('rhum'),
-                    'pressure': closest_hour.get('pres'),
-                    'cloud_cover': closest_hour.get('coco'),
-                })
-                
+                weather["time_diff"] = abs((weather.index - kickoff).total_seconds())
+                closest_hour = weather.loc[weather["time_diff"].idxmin()]
+
+                weather_data.append(
+                    {
+                        "game_id": game["game_id"],
+                        "kickoff_utc": kickoff,
+                        "temp_c": closest_hour.get("temp"),
+                        "wind_mps": closest_hour.get("wspd"),
+                        "precip_mm": closest_hour.get("prcp"),
+                        "humidity": closest_hour.get("rhum"),
+                        "pressure": closest_hour.get("pres"),
+                        "cloud_cover": closest_hour.get("coco"),
+                    }
+                )
+
             except Exception as e:
                 logger.error(f"Error fetching weather for game {game['game_id']}: {e}")
                 continue
-        
+
         if not weather_data:
             logger.warning("No weather data fetched")
             return pd.DataFrame()
-        
+
         df = pd.DataFrame(weather_data)
         logger.info(f"Fetched weather data for {len(df)} games")
         return df
-    
+
     def get_weather_features(self, weather_df: pd.DataFrame) -> pd.DataFrame:
         """Generate weather-based features."""
         features_df = weather_df.copy()
-        
+
         # Temperature features
-        features_df['temp_f'] = features_df['temp_c'] * 9/5 + 32
-        features_df['is_cold'] = features_df['temp_f'] < 32
-        features_df['is_hot'] = features_df['temp_f'] > 85
-        features_df['is_extreme_temp'] = features_df['is_cold'] | features_df['is_hot']
-        
+        features_df["temp_f"] = features_df["temp_c"] * 9 / 5 + 32
+        features_df["is_cold"] = features_df["temp_f"] < 32
+        features_df["is_hot"] = features_df["temp_f"] > 85
+        features_df["is_extreme_temp"] = features_df["is_cold"] | features_df["is_hot"]
+
         # Wind features
-        features_df['wind_mph'] = features_df['wind_mps'] * 2.237
-        features_df['is_windy'] = features_df['wind_mph'] > 15
-        features_df['is_very_windy'] = features_df['wind_mph'] > 25
-        
+        features_df["wind_mph"] = features_df["wind_mps"] * 2.237
+        features_df["is_windy"] = features_df["wind_mph"] > 15
+        features_df["is_very_windy"] = features_df["wind_mph"] > 25
+
         # Precipitation features
-        features_df['is_rainy'] = features_df['precip_mm'] > 0
-        features_df['is_heavy_rain'] = features_df['precip_mm'] > 5
-        
+        features_df["is_rainy"] = features_df["precip_mm"] > 0
+        features_df["is_heavy_rain"] = features_df["precip_mm"] > 5
+
         # Combined weather impact
-        features_df['weather_impact'] = (
-            features_df['is_extreme_temp'].astype(int) +
-            features_df['is_windy'].astype(int) +
-            features_df['is_rainy'].astype(int)
+        features_df["weather_impact"] = (
+            features_df["is_extreme_temp"].astype(int)
+            + features_df["is_windy"].astype(int)
+            + features_df["is_rainy"].astype(int)
         )
-        
+
         return features_df

--- a/src/app/providers/weather_weatherapi.py
+++ b/src/app/providers/weather_weatherapi.py
@@ -13,61 +13,59 @@ from ..logging import get_logger
 logger = get_logger(__name__)
 
 
-class WeatherProvider:
+class WeatherAPIProvider:
     """Weather data provider using WeatherAPI.com."""
-    
+
     def __init__(self, api_key: Optional[str] = None):
         """Initialize weather provider."""
         self.api_key = api_key or settings.weather_api_key
         self.base_url = "http://api.weatherapi.com/v1"
         self.session = requests.Session()
-        self.session.headers.update({
-            'User-Agent': 'CFB-Edge-Platform/1.0'
-        })
-    
+        self.session.headers.update({"User-Agent": "CFB-Edge-Platform/1.0"})
+
     def _get_stadium_location(self, team: str) -> Optional[tuple]:
         """Get stadium coordinates for a team."""
         # This is a simplified mapping - in production, you'd want a comprehensive database
         stadium_locations = {
-            'Alabama': (33.2084, -87.5504),  # Bryant-Denny Stadium
-            'Auburn': (32.6024, -85.4902),   # Jordan-Hare Stadium
-            'Georgia': (33.9500, -83.3750),   # Sanford Stadium
-            'Florida': (29.6500, -82.3500),  # Ben Hill Griffin Stadium
-            'LSU': (30.4115, -91.1899),      # Tiger Stadium
-            'Texas': (30.2836, -97.7316),    # Darrell K Royal Stadium
-            'Oklahoma': (35.2058, -97.4456), # Gaylord Family Stadium
-            'Ohio State': (40.0019, -83.0197), # Ohio Stadium
-            'Michigan': (42.2658, -83.7485),  # Michigan Stadium
-            'Penn State': (40.8123, -77.8561), # Beaver Stadium
-            'USC': (34.2569, -118.2879),      # Los Angeles Memorial Coliseum
-            'UCLA': (34.0722, -118.2437),    # Rose Bowl
-            'Notre Dame': (41.6990, -86.2384), # Notre Dame Stadium
-            'Clemson': (34.6788, -82.8373),  # Memorial Stadium
-            'Florida State': (30.4419, -84.2911), # Doak Campbell Stadium
-            'Miami': (25.6081, -80.4090),    # Hard Rock Stadium
-            'Stanford': (37.4341, -122.1637), # Stanford Stadium
-            'Oregon': (44.0582, -123.0703),  # Autzen Stadium
-            'Washington': (47.6500, -122.3031), # Husky Stadium
-            'Wisconsin': (43.0708, -89.4062), # Camp Randall Stadium
-            'Iowa': (41.6581, -91.5517),    # Kinnick Stadium
-            'Nebraska': (40.8207, -96.7056), # Memorial Stadium
-            'Michigan State': (42.7258, -84.4806), # Spartan Stadium
-            'Minnesota': (44.9778, -93.2225), # Huntington Bank Stadium
-            'Northwestern': (42.0650, -87.6967), # Ryan Field
-            'Purdue': (40.4259, -86.9142),   # Ross-Ade Stadium
-            'Indiana': (39.1817, -86.5264),  # Memorial Stadium
-            'Illinois': (40.1020, -88.2272), # Memorial Stadium
-            'Maryland': (38.9887, -76.9376), # Maryland Stadium
-            'Rutgers': (40.5008, -74.4474),  # SHI Stadium
+            "Alabama": (33.2084, -87.5504),  # Bryant-Denny Stadium
+            "Auburn": (32.6024, -85.4902),  # Jordan-Hare Stadium
+            "Georgia": (33.9500, -83.3750),  # Sanford Stadium
+            "Florida": (29.6500, -82.3500),  # Ben Hill Griffin Stadium
+            "LSU": (30.4115, -91.1899),  # Tiger Stadium
+            "Texas": (30.2836, -97.7316),  # Darrell K Royal Stadium
+            "Oklahoma": (35.2058, -97.4456),  # Gaylord Family Stadium
+            "Ohio State": (40.0019, -83.0197),  # Ohio Stadium
+            "Michigan": (42.2658, -83.7485),  # Michigan Stadium
+            "Penn State": (40.8123, -77.8561),  # Beaver Stadium
+            "USC": (34.2569, -118.2879),  # Los Angeles Memorial Coliseum
+            "UCLA": (34.0722, -118.2437),  # Rose Bowl
+            "Notre Dame": (41.6990, -86.2384),  # Notre Dame Stadium
+            "Clemson": (34.6788, -82.8373),  # Memorial Stadium
+            "Florida State": (30.4419, -84.2911),  # Doak Campbell Stadium
+            "Miami": (25.6081, -80.4090),  # Hard Rock Stadium
+            "Stanford": (37.4341, -122.1637),  # Stanford Stadium
+            "Oregon": (44.0582, -123.0703),  # Autzen Stadium
+            "Washington": (47.6500, -122.3031),  # Husky Stadium
+            "Wisconsin": (43.0708, -89.4062),  # Camp Randall Stadium
+            "Iowa": (41.6581, -91.5517),  # Kinnick Stadium
+            "Nebraska": (40.8207, -96.7056),  # Memorial Stadium
+            "Michigan State": (42.7258, -84.4806),  # Spartan Stadium
+            "Minnesota": (44.9778, -93.2225),  # Huntington Bank Stadium
+            "Northwestern": (42.0650, -87.6967),  # Ryan Field
+            "Purdue": (40.4259, -86.9142),  # Ross-Ade Stadium
+            "Indiana": (39.1817, -86.5264),  # Memorial Stadium
+            "Illinois": (40.1020, -88.2272),  # Memorial Stadium
+            "Maryland": (38.9887, -76.9376),  # Maryland Stadium
+            "Rutgers": (40.5008, -74.4474),  # SHI Stadium
         }
-        
+
         return stadium_locations.get(team)
-    
+
     def _make_request(self, endpoint: str, params: Dict) -> Dict:
         """Make API request to WeatherAPI.com."""
         url = f"{self.base_url}/{endpoint}"
-        params['key'] = self.api_key
-        
+        params["key"] = self.api_key
+
         try:
             response = self.session.get(url, params=params, timeout=30)
             response.raise_for_status()
@@ -75,105 +73,117 @@ class WeatherProvider:
         except requests.exceptions.RequestException as e:
             logger.error(f"WeatherAPI request failed: {e}")
             raise
-    
+
     def fetch_weather(self, games_df: pd.DataFrame) -> pd.DataFrame:
         """Fetch weather data for games."""
         weather_data = []
-        
+
         for _, game in games_df.iterrows():
             try:
                 # Get stadium location
-                home_location = self._get_stadium_location(game['home'])
+                home_location = self._get_stadium_location(game["home"])
                 if not home_location:
                     logger.warning(f"No location data for {game['home']}")
                     continue
-                
+
                 lat, lon = home_location
-                kickoff = game['kickoff_utc']
-                
+                kickoff = game["kickoff_utc"]
+
                 # Format date for WeatherAPI
-                date_str = kickoff.strftime('%Y-%m-%d')
-                
+                date_str = kickoff.strftime("%Y-%m-%d")
+
                 # Fetch weather data for the game date
                 params = {
-                    'q': f"{lat},{lon}",
-                    'dt': date_str,
-                    'hour': kickoff.hour,
+                    "q": f"{lat},{lon}",
+                    "dt": date_str,
+                    "hour": kickoff.hour,
                 }
-                
-                data = self._make_request('forecast.json', params)
-                
-                if 'forecast' not in data or not data['forecast']['forecastday']:
-                    logger.warning(f"No weather forecast for {game['home']} on {date_str}")
+
+                data = self._make_request("forecast.json", params)
+
+                if "forecast" not in data or not data["forecast"]["forecastday"]:
+                    logger.warning(
+                        f"No weather forecast for {game['home']} on {date_str}"
+                    )
                     continue
-                
+
                 # Get weather data for the specific hour
-                forecast_day = data['forecast']['forecastday'][0]
+                forecast_day = data["forecast"]["forecastday"][0]
                 hour_data = None
-                
-                for hour in forecast_day['hour']:
-                    if hour['time'].endswith(f"{kickoff.hour:02d}:00"):
+
+                for hour in forecast_day["hour"]:
+                    if hour["time"].endswith(f"{kickoff.hour:02d}:00"):
                         hour_data = hour
                         break
-                
+
                 if not hour_data:
-                    logger.warning(f"No hourly data for {game['home']} at hour {kickoff.hour}")
+                    logger.warning(
+                        f"No hourly data for {game['home']} at hour {kickoff.hour}"
+                    )
                     continue
-                
-                weather_data.append({
-                    'game_id': game['game_id'],
-                    'kickoff_utc': kickoff,
-                    'temp_c': hour_data['temp_c'],
-                    'wind_mps': hour_data['wind_kph'] / 3.6,  # Convert km/h to m/s
-                    'precip_mm': hour_data['precip_mm'],
-                    'humidity': hour_data['humidity'],
-                    'pressure': hour_data['pressure_mb'],
-                    'cloud_cover': hour_data['cloud'],
-                    'condition': hour_data['condition']['text'],
-                })
-                
+
+                weather_data.append(
+                    {
+                        "game_id": game["game_id"],
+                        "kickoff_utc": kickoff,
+                        "temp_c": hour_data["temp_c"],
+                        "wind_mps": hour_data["wind_kph"] / 3.6,  # Convert km/h to m/s
+                        "precip_mm": hour_data["precip_mm"],
+                        "humidity": hour_data["humidity"],
+                        "pressure": hour_data["pressure_mb"],
+                        "cloud_cover": hour_data["cloud"],
+                        "condition": hour_data["condition"]["text"],
+                    }
+                )
+
             except Exception as e:
                 logger.error(f"Error fetching weather for game {game['game_id']}: {e}")
                 continue
-        
+
         if not weather_data:
             logger.warning("No weather data fetched")
             return pd.DataFrame()
-        
+
         df = pd.DataFrame(weather_data)
         logger.info(f"Fetched weather data for {len(df)} games")
         return df
-    
+
     def get_weather_features(self, weather_df: pd.DataFrame) -> pd.DataFrame:
         """Generate weather-based features."""
         features_df = weather_df.copy()
-        
+
         # Temperature features
-        features_df['temp_f'] = features_df['temp_c'] * 9/5 + 32
-        features_df['is_cold'] = features_df['temp_f'] < 32
-        features_df['is_hot'] = features_df['temp_f'] > 85
-        features_df['is_extreme_temp'] = features_df['is_cold'] | features_df['is_hot']
-        
+        features_df["temp_f"] = features_df["temp_c"] * 9 / 5 + 32
+        features_df["is_cold"] = features_df["temp_f"] < 32
+        features_df["is_hot"] = features_df["temp_f"] > 85
+        features_df["is_extreme_temp"] = features_df["is_cold"] | features_df["is_hot"]
+
         # Wind features
-        features_df['wind_mph'] = features_df['wind_mps'] * 2.237
-        features_df['is_windy'] = features_df['wind_mph'] > 15
-        features_df['is_very_windy'] = features_df['wind_mph'] > 25
-        
+        features_df["wind_mph"] = features_df["wind_mps"] * 2.237
+        features_df["is_windy"] = features_df["wind_mph"] > 15
+        features_df["is_very_windy"] = features_df["wind_mph"] > 25
+
         # Precipitation features
-        features_df['is_rainy'] = features_df['precip_mm'] > 0
-        features_df['is_heavy_rain'] = features_df['precip_mm'] > 5
-        
+        features_df["is_rainy"] = features_df["precip_mm"] > 0
+        features_df["is_heavy_rain"] = features_df["precip_mm"] > 5
+
         # Weather condition features
-        features_df['is_clear'] = features_df['condition'].str.contains('Clear|Sunny', case=False, na=False)
-        features_df['is_cloudy'] = features_df['condition'].str.contains('Cloud|Overcast', case=False, na=False)
-        features_df['is_stormy'] = features_df['condition'].str.contains('Storm|Thunder|Lightning', case=False, na=False)
-        
-        # Combined weather impact
-        features_df['weather_impact'] = (
-            features_df['is_extreme_temp'].astype(int) +
-            features_df['is_windy'].astype(int) +
-            features_df['is_rainy'].astype(int) +
-            features_df['is_stormy'].astype(int)
+        features_df["is_clear"] = features_df["condition"].str.contains(
+            "Clear|Sunny", case=False, na=False
         )
-        
+        features_df["is_cloudy"] = features_df["condition"].str.contains(
+            "Cloud|Overcast", case=False, na=False
+        )
+        features_df["is_stormy"] = features_df["condition"].str.contains(
+            "Storm|Thunder|Lightning", case=False, na=False
+        )
+
+        # Combined weather impact
+        features_df["weather_impact"] = (
+            features_df["is_extreme_temp"].astype(int)
+            + features_df["is_windy"].astype(int)
+            + features_df["is_rainy"].astype(int)
+            + features_df["is_stormy"].astype(int)
+        )
+
         return features_df


### PR DESCRIPTION
## Summary
- rename weather provider classes for Meteostat and WeatherAPI
- allow ingest pipeline to accept any weather provider instance
- add CLI flag to select weather data provider

## Testing
- `pre-commit run --files src/app/providers/weather_meteostat.py src/app/providers/weather_weatherapi.py src/app/pipelines/ingest.py src/app/cli.py` *(fails: ruff TOML parse error, ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68bdc3c5314483288ad0aa4e018253b2