### PR TITLE
Persist test split artifacts for calibration

### DIFF
--- a/src/app/models/calibration.py
+++ b/src/app/models/calibration.py
@@ -1,10 +1,20 @@
-"""Model calibration pipeline."""
+"""Model calibration pipeline.
 
-import logging
+This module loads trained models and their associated test data artifacts
+from :data:`settings.artifacts_dir`. The following files are expected for a
+given ``market`` and training ``timestamp``::
+
+    model_{market}_{timestamp}.pkl
+    X_test_{market}_{timestamp}.pkl
+    y_test_{market}_{timestamp}.pkl
+
+The saved ``X_test`` and ``y_test`` are used to perform probability
+calibration without regenerating or simulating data.
+"""
+
 import pickle
 from datetime import datetime
-from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -21,158 +31,168 @@ logger = get_logger(__name__)
 
 class ModelCalibrator:
     """Calibrator for ML model probabilities."""
-    
+
     def __init__(self):
         """Initialize model calibrator."""
         self.artifacts_dir = settings.artifacts_dir
         self.artifacts_dir.mkdir(exist_ok=True)
         self.calibration_method = settings.calibration_method
-    
-    def calibrate_probabilities(self, model, X_test: pd.DataFrame, y_test: pd.Series, 
-                               method: str = "isotonic") -> Dict:
+
+    def calibrate_probabilities(
+        self, model, X_test: pd.DataFrame, y_test: pd.Series, method: str = "isotonic"
+    ) -> Dict:
         """Calibrate model probabilities."""
         logger.info(f"Calibrating probabilities using {method} method")
-        
+
         # Get uncalibrated probabilities
         y_pred_proba = model.predict_proba(X_test)[:, 1]
-        
+
         # Apply calibration
         if method == "isotonic":
-            calibrator = IsotonicRegression(out_of_bounds='clip')
+            calibrator = IsotonicRegression(out_of_bounds="clip")
             calibrator.fit(y_pred_proba, y_test)
             y_calibrated = calibrator.predict(y_pred_proba)
         elif method == "platt":
-            calibrator = CalibratedClassifierCV(model, method='sigmoid', cv='prefit')
+            calibrator = CalibratedClassifierCV(model, method="sigmoid", cv="prefit")
             calibrator.fit(X_test, y_test)
             y_calibrated = calibrator.predict_proba(X_test)[:, 1]
         else:
             raise ValueError(f"Unknown calibration method: {method}")
-        
+
         # Calculate calibration metrics
         brier_score = brier_score_loss(y_test, y_calibrated)
         log_loss_score = log_loss(y_test, y_calibrated)
-        
+
         # Calculate calibration curve
         fraction_of_positives, mean_predicted_value = calibration_curve(
             y_test, y_calibrated, n_bins=10
         )
-        
+
         metrics = {
-            'brier_score': brier_score,
-            'log_loss': log_loss_score,
-            'calibration_curve': {
-                'fraction_of_positives': fraction_of_positives,
-                'mean_predicted_value': mean_predicted_value,
-            }
+            "brier_score": brier_score,
+            "log_loss": log_loss_score,
+            "calibration_curve": {
+                "fraction_of_positives": fraction_of_positives,
+                "mean_predicted_value": mean_predicted_value,
+            },
         }
-        
+
         logger.info(f"Calibration completed. Brier score: {brier_score:.4f}")
-        
+
         return {
-            'calibrator': calibrator,
-            'y_calibrated': y_calibrated,
-            'metrics': metrics,
+            "calibrator": calibrator,
+            "y_calibrated": y_calibrated,
+            "metrics": metrics,
         }
-    
-    def plot_calibration_curve(self, y_test: pd.Series, y_pred_proba: np.ndarray, 
-                              y_calibrated: np.ndarray, market: str) -> None:
+
+    def plot_calibration_curve(
+        self,
+        y_test: pd.Series,
+        y_pred_proba: np.ndarray,
+        y_calibrated: np.ndarray,
+        market: str,
+    ) -> None:
         """Plot calibration curve."""
         logger.info(f"Creating calibration plot for {market}")
-        
+
         fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 5))
-        
+
         # Uncalibrated probabilities
         fraction_of_positives, mean_predicted_value = calibration_curve(
             y_test, y_pred_proba, n_bins=10
         )
-        
-        ax1.plot(mean_predicted_value, fraction_of_positives, "s-", label="Uncalibrated")
+
+        ax1.plot(
+            mean_predicted_value, fraction_of_positives, "s-", label="Uncalibrated"
+        )
         ax1.plot([0, 1], [0, 1], "k:", label="Perfectly calibrated")
         ax1.set_xlabel("Mean predicted probability")
         ax1.set_ylabel("Fraction of positives")
         ax1.set_title(f"Calibration Curve - {market} (Uncalibrated)")
         ax1.legend()
         ax1.grid(True)
-        
+
         # Calibrated probabilities
         fraction_of_positives_cal, mean_predicted_value_cal = calibration_curve(
             y_test, y_calibrated, n_bins=10
         )
-        
-        ax2.plot(mean_predicted_value_cal, fraction_of_positives_cal, "s-", label="Calibrated")
+
+        ax2.plot(
+            mean_predicted_value_cal,
+            fraction_of_positives_cal,
+            "s-",
+            label="Calibrated",
+        )
         ax2.plot([0, 1], [0, 1], "k:", label="Perfectly calibrated")
         ax2.set_xlabel("Mean predicted probability")
         ax2.set_ylabel("Fraction of positives")
         ax2.set_title(f"Calibration Curve - {market} (Calibrated)")
         ax2.legend()
         ax2.grid(True)
-        
+
         plt.tight_layout()
-        
+
         # Save plot
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         plot_filename = f"calibration_curve_{market}_{timestamp}.png"
         plot_path = self.artifacts_dir / plot_filename
-        plt.savefig(plot_path, dpi=300, bbox_inches='tight')
+        plt.savefig(plot_path, dpi=300, bbox_inches="tight")
         plt.close()
-        
+
         logger.info(f"Saved calibration plot to {plot_path}")
-    
+
     def save_calibrator(self, calibrator, market: str) -> None:
         """Save calibrated model."""
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        
+
         calibrator_filename = f"calibrator_{market}_{timestamp}.pkl"
         calibrator_path = self.artifacts_dir / calibrator_filename
-        
-        with open(calibrator_path, 'wb') as f:
+
+        with open(calibrator_path, "wb") as f:
             pickle.dump(calibrator, f)
-        
+
         logger.info(f"Saved calibrator to {calibrator_path}")
-    
+
     def calibrate_market_model(self, market: str) -> Dict:
         """Calibrate model for a specific market."""
         logger.info(f"Calibrating model for market: {market}")
-        
+
         # Load trained model
         model_files = list(self.artifacts_dir.glob(f"model_{market}_*.pkl"))
         if not model_files:
             raise ValueError(f"No trained model found for market: {market}")
-        
+
         latest_model = max(model_files, key=lambda x: x.stat().st_mtime)
-        
-        with open(latest_model, 'rb') as f:
+
+        with open(latest_model, "rb") as f:
             model = pickle.load(f)
-        
-        # Load test data (this would need to be saved during training)
-        # For now, we'll simulate this
-        logger.warning("Using simulated test data for calibration")
-        
-        # Create simulated test data
-        np.random.seed(settings.random_seed)
-        n_samples = 1000
-        n_features = 20
-        
-        X_test = pd.DataFrame(
-            np.random.randn(n_samples, n_features),
-            columns=[f'feature_{i}' for i in range(n_features)]
-        )
-        
-        y_test = pd.Series(np.random.binomial(1, 0.5, n_samples))
-        
+
+        # Load saved test data corresponding to the model
+        timestamp = latest_model.stem.split("_")[-1]
+        X_test_path = self.artifacts_dir / f"X_test_{market}_{timestamp}.pkl"
+        y_test_path = self.artifacts_dir / f"y_test_{market}_{timestamp}.pkl"
+
+        if not X_test_path.exists() or not y_test_path.exists():
+            raise ValueError(f"Missing test data artifacts for market: {market}")
+
+        with open(X_test_path, "rb") as f:
+            X_test = pickle.load(f)
+        with open(y_test_path, "rb") as f:
+            y_test = pickle.load(f)
+
         # Calibrate probabilities
         calibration_results = self.calibrate_probabilities(
             model, X_test, y_test, self.calibration_method
         )
-        
+
         # Create calibration plot
         y_pred_proba = model.predict_proba(X_test)[:, 1]
         self.plot_calibration_curve(
-            y_test, y_pred_proba, calibration_results['y_calibrated'], market
+            y_test, y_pred_proba, calibration_results["y_calibrated"], market
         )
-        
+
         # Save calibrator
-        self.save_calibrator(calibration_results['calibrator'], market)
-        
+        self.save_calibrator(calibration_results["calibrator"], market)
+
         logger.info(f"Model calibration completed for {market}")
         return calibration_results

--- a/src/app/models/train.py
+++ b/src/app/models/train.py
@@ -1,178 +1,212 @@
-"""Model training pipeline."""
+"""Model training pipeline.
 
-import logging
+Artifacts are stored under :data:`settings.artifacts_dir` using the
+following naming convention:
+
+``model_{market}_{timestamp}.pkl``
+    Trained model for ``market``.
+``metadata_{market}_{timestamp}.pkl``
+    Training metadata including performance metrics.
+``X_test_{market}_{timestamp}.pkl``
+    Test feature matrix used during training split.
+``y_test_{market}_{timestamp}.pkl``
+    Test labels corresponding to ``X_test``.
+
+These artifacts are later consumed by the calibration module.
+"""
+
 import pickle
 from datetime import datetime
-from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, Tuple
 
-import numpy as np
 import pandas as pd
-from sklearn.model_selection import train_test_split, TimeSeriesSplit
-from sklearn.metrics import accuracy_score, precision_score, recall_score, f1_score, roc_auc_score
+from sklearn.metrics import (
+    accuracy_score,
+    f1_score,
+    precision_score,
+    recall_score,
+    roc_auc_score,
+)
 import xgboost as xgb
 
 from ..config import settings
 from ..logging import get_logger
-from ..utils.betting import american_to_prob, remove_vig
 
 logger = get_logger(__name__)
 
 
 class ModelTrainer:
     """Trainer for ML models."""
-    
+
     def __init__(self):
         """Initialize model trainer."""
         self.artifacts_dir = settings.artifacts_dir
         self.artifacts_dir.mkdir(exist_ok=True)
         self.random_seed = settings.random_seed
-    
-    def prepare_training_data(self, features_df: pd.DataFrame, labels_df: pd.DataFrame) -> Tuple[pd.DataFrame, pd.Series]:
+
+    def prepare_training_data(
+        self, features_df: pd.DataFrame, labels_df: pd.DataFrame
+    ) -> Tuple[pd.DataFrame, pd.Series]:
         """Prepare training data by joining features and labels."""
         logger.info("Preparing training data")
-        
+
         # Join features and labels
-        training_data = features_df.merge(labels_df, on='game_id', how='inner')
-        
+        training_data = features_df.merge(labels_df, on="game_id", how="inner")
+
         # Separate features and target
-        feature_cols = [col for col in training_data.columns 
-                       if col not in ['game_id', 'result_cover', 'result_over', 'home_team', 'away_team']]
-        
+        feature_cols = [
+            col
+            for col in training_data.columns
+            if col
+            not in ["game_id", "result_cover", "result_over", "home_team", "away_team"]
+        ]
+
         X = training_data[feature_cols]
-        
+
         # Determine target column based on labels
-        if 'result_cover' in labels_df.columns:
-            y = training_data['result_cover']
-        elif 'result_over' in labels_df.columns:
-            y = training_data['result_over']
+        if "result_cover" in labels_df.columns:
+            y = training_data["result_cover"]
+        elif "result_over" in labels_df.columns:
+            y = training_data["result_over"]
         else:
             raise ValueError("No valid target column found in labels")
-        
+
         # Handle missing values
         X = X.fillna(0)
-        
-        logger.info(f"Prepared training data: {len(X)} samples, {len(feature_cols)} features")
+
+        logger.info(
+            f"Prepared training data: {len(X)} samples, {len(feature_cols)} features"
+        )
         return X, y
-    
-    def train_xgboost_model(self, X: pd.DataFrame, y: pd.Series, 
-                           market: str, test_size: float = 0.2) -> Dict:
+
+    def train_xgboost_model(
+        self, X: pd.DataFrame, y: pd.Series, market: str, test_size: float = 0.2
+    ) -> Dict:
         """Train XGBoost model with time-based split."""
         logger.info(f"Training XGBoost model for {market}")
-        
+
         # Time-based split (assuming data is ordered by date)
         split_idx = int(len(X) * (1 - test_size))
         X_train, X_test = X.iloc[:split_idx], X.iloc[split_idx:]
         y_train, y_test = y.iloc[:split_idx], y.iloc[split_idx:]
-        
+
         # XGBoost parameters
         params = {
-            'objective': 'binary:logistic',
-            'eval_metric': 'logloss',
-            'random_state': self.random_seed,
-            'n_estimators': 1000,
-            'max_depth': 6,
-            'learning_rate': 0.1,
-            'subsample': 0.8,
-            'colsample_bytree': 0.8,
-            'early_stopping_rounds': 50,
+            "objective": "binary:logistic",
+            "eval_metric": "logloss",
+            "random_state": self.random_seed,
+            "n_estimators": 1000,
+            "max_depth": 6,
+            "learning_rate": 0.1,
+            "subsample": 0.8,
+            "colsample_bytree": 0.8,
+            "early_stopping_rounds": 50,
         }
-        
+
         # Train model
         model = xgb.XGBClassifier(**params)
-        model.fit(
-            X_train, y_train,
-            eval_set=[(X_test, y_test)],
-            verbose=False
-        )
-        
+        model.fit(X_train, y_train, eval_set=[(X_test, y_test)], verbose=False)
+
         # Make predictions
         y_pred_proba = model.predict_proba(X_test)[:, 1]
         y_pred = model.predict(X_test)
-        
+
         # Calculate metrics
         metrics = {
-            'accuracy': accuracy_score(y_test, y_pred),
-            'precision': precision_score(y_test, y_pred),
-            'recall': recall_score(y_test, y_pred),
-            'f1': f1_score(y_test, y_pred),
-            'roc_auc': roc_auc_score(y_test, y_pred_proba),
+            "accuracy": accuracy_score(y_test, y_pred),
+            "precision": precision_score(y_test, y_pred),
+            "recall": recall_score(y_test, y_pred),
+            "f1": f1_score(y_test, y_pred),
+            "roc_auc": roc_auc_score(y_test, y_pred_proba),
         }
-        
+
         # Feature importance
-        feature_importance = pd.DataFrame({
-            'feature': X.columns,
-            'importance': model.feature_importances_
-        }).sort_values('importance', ascending=False)
-        
+        feature_importance = pd.DataFrame(
+            {"feature": X.columns, "importance": model.feature_importances_}
+        ).sort_values("importance", ascending=False)
+
         logger.info(f"Model training completed. ROC-AUC: {metrics['roc_auc']:.4f}")
-        
+
         return {
-            'model': model,
-            'metrics': metrics,
-            'feature_importance': feature_importance,
-            'X_test': X_test,
-            'y_test': y_test,
-            'y_pred_proba': y_pred_proba,
-            'y_pred': y_pred,
+            "model": model,
+            "metrics": metrics,
+            "feature_importance": feature_importance,
+            "X_test": X_test,
+            "y_test": y_test,
+            "y_pred_proba": y_pred_proba,
+            "y_pred": y_pred,
         }
-    
+
     def save_model(self, model_results: Dict, market: str) -> None:
         """Save trained model and metadata."""
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        
+
         # Save model
         model_filename = f"model_{market}_{timestamp}.pkl"
         model_path = self.artifacts_dir / model_filename
-        
-        with open(model_path, 'wb') as f:
-            pickle.dump(model_results['model'], f)
-        
+
+        with open(model_path, "wb") as f:
+            pickle.dump(model_results["model"], f)
+
+        # Save test split for calibration
+        X_test_filename = f"X_test_{market}_{timestamp}.pkl"
+        X_test_path = self.artifacts_dir / X_test_filename
+        with open(X_test_path, "wb") as f:
+            pickle.dump(model_results["X_test"], f)
+
+        y_test_filename = f"y_test_{market}_{timestamp}.pkl"
+        y_test_path = self.artifacts_dir / y_test_filename
+        with open(y_test_path, "wb") as f:
+            pickle.dump(model_results["y_test"], f)
+
         # Save metadata
         metadata = {
-            'market': market,
-            'timestamp': timestamp,
-            'metrics': model_results['metrics'],
-            'feature_importance': model_results['feature_importance'].to_dict(),
-            'model_path': str(model_path),
+            "market": market,
+            "timestamp": timestamp,
+            "metrics": model_results["metrics"],
+            "feature_importance": model_results["feature_importance"].to_dict(),
+            "model_path": str(model_path),
+            "X_test_path": str(X_test_path),
+            "y_test_path": str(y_test_path),
         }
-        
+
         metadata_filename = f"metadata_{market}_{timestamp}.pkl"
         metadata_path = self.artifacts_dir / metadata_filename
-        
-        with open(metadata_path, 'wb') as f:
+
+        with open(metadata_path, "wb") as f:
             pickle.dump(metadata, f)
-        
+
         logger.info(f"Saved model to {model_path}")
+        logger.info(f"Saved test data to {X_test_path} and {y_test_path}")
         logger.info(f"Saved metadata to {metadata_path}")
-    
+
     def train_market_model(self, market: str) -> Dict:
         """Train model for a specific market."""
         logger.info(f"Training model for market: {market}")
-        
+
         # Load feature data
         feature_files = list(settings.data_dir.glob("gold/features_*.parquet"))
         if not feature_files:
             raise ValueError("No feature data found")
-        
+
         latest_features = max(feature_files, key=lambda x: x.stat().st_mtime)
         features_df = pd.read_parquet(latest_features)
-        
+
         # Load labels for the market
         labels_file = settings.data_dir / f"gold/labels_{market}.parquet"
         if not labels_file.exists():
             raise ValueError(f"No labels found for market: {market}")
-        
+
         labels_df = pd.read_parquet(labels_file)
-        
+
         # Prepare training data
         X, y = self.prepare_training_data(features_df, labels_df)
-        
+
         # Train model
         model_results = self.train_xgboost_model(X, y, market)
-        
+
         # Save model
         self.save_model(model_results, market)
-        
+
         logger.info(f"Model training completed for {market}")
         return model_results


### PR DESCRIPTION
## Summary
- save `X_test` and `y_test` during training and record paths in metadata
- load saved test data in the calibration pipeline instead of generating dummy data
- document artifact file paths in training and calibration modules

## Testing
- `pre-commit run --files src/app/models/train.py src/app/models/calibration.py` *(fails: Unknown rule selector: `W503`; ModuleNotFoundError: No module named 'app`)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc70d620c83289bf18e32c029044c