### PR TITLE
Use real partial scores for label generation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ build-backend = "poetry.core.masonry.api"
 target-version = "py311"
 line-length = 88
 select = ["E", "F", "W", "C90", "I", "N", "UP", "YTT", "S", "BLE", "FBT", "B", "A", "COM", "C4", "DTZ", "T10", "EM", "EXE", "FA", "ISC", "ICN", "G", "INP", "PIE", "T20", "PYI", "PT", "Q", "RSE", "RET", "SLF", "SLOT", "SIM", "TID", "TCH", "INT", "ARG", "PTH", "TD", "FIX", "ERA", "PD", "PGH", "PL", "TRY", "FLY", "NPY", "AIR", "PERF", "FURB", "LOG", "RUF"]
-ignore = ["E501", "W503", "S101", "PLR2004", "PLR0913", "PLR0912", "PLR0915"]
+ignore = ["E501", "S101", "PLR2004", "PLR0913", "PLR0912", "PLR0915"]
 
 [tool.black]
 line-length = 88

--- a/src/app/pipelines/labels.py
+++ b/src/app/pipelines/labels.py
@@ -1,57 +1,85 @@
 """Labels pipeline for creating betting outcome labels."""
 
-import logging
-from pathlib import Path
-from typing import Dict, List, Optional
-
 import pandas as pd
 
-from ..config import settings
-from ..logging import get_logger
-from ..validation.schemas import LabelATS, LabelTotal
+from app.config import settings
+from app.logging import get_logger
+from app.validation.schemas import LabelATS, LabelTotal
 
 logger = get_logger(__name__)
 
 
 class LabelsPipeline:
     """Pipeline for creating betting outcome labels."""
-    
+
     def __init__(self):
         """Initialize labels pipeline."""
         self.data_dir = settings.data_dir
         self.gold_dir = self.data_dir / "gold"
         self.gold_dir.mkdir(exist_ok=True)
-    
-    def create_ats_labels(self, games_df: pd.DataFrame, period: str = "game") -> pd.DataFrame:
-        """Create ATS (Against The Spread) labels."""
-        logger.info(f"Creating ATS labels for {period} period")
-        
+
+    def _get_period_scores(self, game: pd.Series, period: str) -> tuple[float, float]:
+        """Return home and away scores for a given period.
+
+        Scores are sourced from ``home_score``/``away_score`` for the full game,
+        ``home_score_1H``/``away_score_1H`` for first-half lines, and
+        ``home_score_1Q``/``away_score_1Q`` for first-quarter lines when those
+        columns are available. If the period-specific columns are missing, the
+        scores fall back to scaled final scores.
+        """
+
+        if period == "game":
+            return game.get("home_score", 0), game.get("away_score", 0)
+
+        if period == "1H":
+            home_score = game.get("home_score_1H")
+            away_score = game.get("away_score_1H")
+            if pd.isna(home_score) or pd.isna(away_score):
+                home_score = game.get("home_score", 0) * 0.5
+                away_score = game.get("away_score", 0) * 0.5
+            return home_score, away_score
+
+        if period == "1Q":
+            home_score = game.get("home_score_1Q")
+            away_score = game.get("away_score_1Q")
+            if pd.isna(home_score) or pd.isna(away_score):
+                home_score = game.get("home_score", 0) * 0.25
+                away_score = game.get("away_score", 0) * 0.25
+            return home_score, away_score
+
+        msg = f"Unsupported period: {period}"
+        raise ValueError(msg)
+
+    def create_ats_labels(
+        self,
+        games_df: pd.DataFrame,
+        period: str = "game",
+    ) -> pd.DataFrame:
+        """Create ATS (Against The Spread) labels.
+
+        Source columns: ``home_score``/``away_score`` for game lines,
+        ``home_score_1H``/``away_score_1H`` for first-half lines, and
+        ``home_score_1Q``/``away_score_1Q`` for first-quarter lines.
+        """
+        logger.info("Creating ATS labels for %s period", period)
+
         labels_data = []
-        
+
         for _, game in games_df.iterrows():
             try:
                 # Get spread line for the period
                 spread_col = f"home_handicap_{period}_spread"
                 if spread_col not in game.index or pd.isna(game[spread_col]):
                     continue
-                
+
                 spread_line = game[spread_col]
-                
+
                 # Get scores for the period
-                if period == "game":
-                    home_score = game.get('home_score', 0)
-                    away_score = game.get('away_score', 0)
-                elif period == "1H":
-                    # Would need halftime scores - using simplified calculation
-                    home_score = game.get('home_score', 0) * 0.5
-                    away_score = game.get('away_score', 0) * 0.5
-                elif period == "1Q":
-                    # Would need first quarter scores - using simplified calculation
-                    home_score = game.get('home_score', 0) * 0.25
-                    away_score = game.get('away_score', 0) * 0.25
-                else:
+                try:
+                    home_score, away_score = self._get_period_scores(game, period)
+                except ValueError:
                     continue
-                
+
                 # Calculate ATS result
                 # Positive spread means home team is favored
                 if spread_line > 0:
@@ -60,115 +88,127 @@ class LabelsPipeline:
                 else:
                     # Away team is favored
                     result_cover = (away_score - home_score) > abs(spread_line)
-                
-                labels_data.append({
-                    'game_id': game['game_id'],
-                    'period': period,
-                    'spread_line': spread_line,
-                    'result_cover': result_cover,
-                    'home_score': home_score,
-                    'away_score': away_score,
-                    'home_team': game['home'],
-                    'away_team': game['away'],
-                })
-                
-            except Exception as e:
-                logger.warning(f"Error creating ATS label for game {game['game_id']}: {e}")
+
+                labels_data.append(
+                    {
+                        "game_id": game["game_id"],
+                        "period": period,
+                        "spread_line": spread_line,
+                        "result_cover": result_cover,
+                        "home_score": home_score,
+                        "away_score": away_score,
+                        "home_team": game["home"],
+                        "away_team": game["away"],
+                    },
+                )
+
+            except Exception as e:  # noqa: BLE001
+                logger.warning(
+                    "Error creating ATS label for game %s: %s",
+                    game["game_id"],
+                    e,
+                )
                 continue
-        
+
         if not labels_data:
             logger.warning("No ATS labels created")
             return pd.DataFrame()
-        
+
         labels_df = pd.DataFrame(labels_data)
-        
+
         # Validate using schema
         try:
             for _, row in labels_df.iterrows():
                 LabelATS(**row.to_dict())
-        except Exception as e:
-            logger.error(f"Schema validation failed: {e}")
+        except Exception:
+            logger.exception("Schema validation failed")
             raise
-        
-        logger.info(f"Created {len(labels_df)} ATS labels for {period} period")
+
+        logger.info("Created %s ATS labels for %s period", len(labels_df), period)
         return labels_df
-    
-    def create_total_labels(self, games_df: pd.DataFrame, period: str = "game") -> pd.DataFrame:
-        """Create totals (over/under) labels."""
-        logger.info(f"Creating total labels for {period} period")
-        
+
+    def create_total_labels(
+        self,
+        games_df: pd.DataFrame,
+        period: str = "game",
+    ) -> pd.DataFrame:
+        """Create totals (over/under) labels.
+
+        Source columns mirror :meth:`create_ats_labels` and come from
+        ``home_score``/``away_score``, ``home_score_1H``/``away_score_1H``, and
+        ``home_score_1Q``/``away_score_1Q``.
+        """
+        logger.info("Creating total labels for %s period", period)
+
         labels_data = []
-        
+
         for _, game in games_df.iterrows():
             try:
                 # Get total line for the period
                 total_col = f"total_points_{period}_total"
                 if total_col not in game.index or pd.isna(game[total_col]):
                     continue
-                
+
                 total_line = game[total_col]
-                
+
                 # Get scores for the period
-                if period == "game":
-                    home_score = game.get('home_score', 0)
-                    away_score = game.get('away_score', 0)
-                elif period == "1H":
-                    # Would need halftime scores - using simplified calculation
-                    home_score = game.get('home_score', 0) * 0.5
-                    away_score = game.get('away_score', 0) * 0.5
-                elif period == "1Q":
-                    # Would need first quarter scores - using simplified calculation
-                    home_score = game.get('home_score', 0) * 0.25
-                    away_score = game.get('away_score', 0) * 0.25
-                else:
+                try:
+                    home_score, away_score = self._get_period_scores(game, period)
+                except ValueError:
                     continue
-                
+
                 # Calculate total result
                 total_points = home_score + away_score
                 result_over = total_points > total_line
-                
-                labels_data.append({
-                    'game_id': game['game_id'],
-                    'period': period,
-                    'total_line': total_line,
-                    'result_over': result_over,
-                    'total_points': total_points,
-                    'home_score': home_score,
-                    'away_score': away_score,
-                    'home_team': game['home'],
-                    'away_team': game['away'],
-                })
-                
-            except Exception as e:
-                logger.warning(f"Error creating total label for game {game['game_id']}: {e}")
+
+                labels_data.append(
+                    {
+                        "game_id": game["game_id"],
+                        "period": period,
+                        "total_line": total_line,
+                        "result_over": result_over,
+                        "total_points": total_points,
+                        "home_score": home_score,
+                        "away_score": away_score,
+                        "home_team": game["home"],
+                        "away_team": game["away"],
+                    },
+                )
+
+            except Exception as e:  # noqa: BLE001
+                logger.warning(
+                    "Error creating total label for game %s: %s",
+                    game["game_id"],
+                    e,
+                )
                 continue
-        
+
         if not labels_data:
             logger.warning("No total labels created")
             return pd.DataFrame()
-        
+
         labels_df = pd.DataFrame(labels_data)
-        
+
         # Validate using schema
         try:
             for _, row in labels_df.iterrows():
                 LabelTotal(**row.to_dict())
-        except Exception as e:
-            logger.error(f"Schema validation failed: {e}")
+        except Exception:
+            logger.exception("Schema validation failed")
             raise
-        
-        logger.info(f"Created {len(labels_df)} total labels for {period} period")
+
+        logger.info("Created %s total labels for %s period", len(labels_df), period)
         return labels_df
-    
-    def create_all_labels(self, games_df: pd.DataFrame) -> Dict[str, pd.DataFrame]:
+
+    def create_all_labels(self, games_df: pd.DataFrame) -> dict[str, pd.DataFrame]:
         """Create all possible labels."""
         logger.info("Creating all labels")
-        
+
         periods = ["game", "1H", "1Q"]
         markets = ["ats", "total"]
-        
+
         all_labels = {}
-        
+
         for period in periods:
             for market in markets:
                 if market == "ats":
@@ -177,39 +217,52 @@ class LabelsPipeline:
                 else:
                     labels_df = self.create_total_labels(games_df, period)
                     key = f"total_{period}"
-                
+
                 if not labels_df.empty:
                     all_labels[key] = labels_df
-        
-        logger.info(f"Created labels for {len(all_labels)} market-period combinations")
+
+        logger.info("Created labels for %s market-period combinations", len(all_labels))
         return all_labels
-    
-    def save_labels(self, labels_dict: Dict[str, pd.DataFrame]) -> None:
+
+    def save_labels(self, labels_dict: dict[str, pd.DataFrame]) -> None:
         """Save labels to gold layer."""
         for market_period, labels_df in labels_dict.items():
             filename = f"labels_{market_period}.parquet"
             filepath = self.gold_dir / filename
             labels_df.to_parquet(filepath, index=False)
-            logger.info(f"Saved {len(labels_df)} {market_period} labels to {filepath}")
-    
-    def run_label_creation(self, season: int, week: Optional[int] = None) -> Dict[str, pd.DataFrame]:
+            logger.info(
+                "Saved %s %s labels to %s",
+                len(labels_df),
+                market_period,
+                filepath,
+            )
+
+    def run_label_creation(
+        self,
+        season: int,
+        week: int | None = None,
+    ) -> dict[str, pd.DataFrame]:
         """Run full label creation pipeline."""
-        logger.info(f"Starting label creation for season {season}" + (f", week {week}" if week else ""))
-        
+        if week is not None:
+            logger.info("Starting label creation for season %s, week %s", season, week)
+        else:
+            logger.info("Starting label creation for season %s", season)
+
         # Load feature data
         feature_files = list(self.gold_dir.glob("features_*.parquet"))
         if not feature_files:
-            raise ValueError("No feature data found in gold layer")
-        
+            msg = "No feature data found in gold layer"
+            raise ValueError(msg)
+
         # Load the most recent feature data
         latest_file = max(feature_files, key=lambda x: x.stat().st_mtime)
         games_df = pd.read_parquet(latest_file)
-        
+
         # Create all labels
         all_labels = self.create_all_labels(games_df)
-        
+
         # Save labels
         self.save_labels(all_labels)
-        
+
         logger.info("Label creation completed successfully")
         return all_labels


### PR DESCRIPTION
## Summary
- derive first-half and first-quarter scores directly from CFBD columns when available, falling back to scaled finals
- document score source columns in ATS and totals label helpers
- drop deprecated `W503` ignore from ruff config

## Testing
- `PYTHONPATH=src pre-commit run --files src/app/pipelines/labels.py pyproject.toml` *(fails: tests/test_betting.py::test_calculate_edge - assert 0.09999999999999998 == 0.1)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc70a51048328aa87ac7f90a040a3